### PR TITLE
Config's ccflags must always be used

### DIFF
--- a/lib/ExtUtils/CppGuess.pm
+++ b/lib/ExtUtils/CppGuess.pm
@@ -170,7 +170,8 @@ sub _get_cflags {
 
     $self->guess_compiler or die;
 
-    my $cflags = $self->{guess}{extra_cflags};
+    my $cflags = $self->_config->{ccflags};
+    $cflags .= ' ' . $self->{guess}{extra_cflags};
     $cflags .= ' ' . $self->{extra_compiler_flags}
       if defined $self->{extra_compiler_flags};
 
@@ -253,8 +254,6 @@ sub _guess_unix {
       extra_cflags => ' -xc++ ',
       extra_lflags => ' -lstdc++ ',
     };
-    $self->{guess}{extra_cflags} .= ' -D_FILE_OFFSET_BITS=64'
-      if $self->_config->{ccflags} =~ /-D_FILE_OFFSET_BITS=64/;
     $self->{guess}{extra_lflags} .= ' -lgcc_s'
       if $self->_os eq 'netbsd' && $self->{guess}{extra_lflags} !~ /-lgcc_s/;
 


### PR DESCRIPTION
This fixes #9 .

before
```
C:\sources\extutils-cppguess>dmake test
cp lib/ExtUtils/CppGuess.pm blib\lib\ExtUtils\CppGuess.pm
"C:\sp522\perl\bin\perl.exe" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "u
ndef *Test::Harness::Switches; test_harness(0, 'blib\lib', 'blib\arch')" t/*.t
t/001_load.t .......... 1/2 # EUMM:$VAR1 = {
#           'CCFLAGS' => ' -xc++ ',
#           'dynamic_lib' => {
#                              'OTHERLDFLAGS' => ' -lstdc++ '
#                            }
#         };
# ---
# MB:$VAR1 = {
#           'extra_compiler_flags' => ' -xc++ ',
#           'extra_linker_flags' => ' -lstdc++ '
#         };
t/001_load.t .......... ok
t/010_module_build.t .. ok
t/011_makemaker.t .....
#   Failed test 'build with ExtUtils::MakeMaker'
t/011_makemaker.t ..... 1/1 #   at t/011_makemaker.t line 12.
# Makefile.PL output
# ========================================
# Checking if your kit is complete...
# Looks good
# Generating a dmake-style Makefile
# Writing Makefile for CppGuessTest
# Writing MYMETA.yml and MYMETA.json
# ========================================
# make output
# ========================================
# cp lib/CppGuessTest.pm blib\lib\CppGuessTest.pm
# Running Mkbootstrap for CppGuessTest ()
# "C:\sp522\perl\bin\perl.exe" -MExtUtils::Command -e chmod -- 644 "CppGuessTest
.bs"
# "C:\sp522\perl\bin\perl.exe" "C:\sp522\perl\lib\ExtUtils\xsubpp"  -typemap "C:
\sp522\perl\lib\ExtUtils\typemap" -typemap "typemap"  CppGuessTest.xs > CppGuess
Test.xsc && "C:\sp522\perl\bin\perl.exe" -MExtUtils::Command -e mv -- CppGuessTe
st.xsc CppGuessTest.c
# gcc -c        -xc++ -s -O2      -DVERSION=\"0.01\"    -DXS_VERSION=\"0.01\"  "
-IC:\sp522\perl\lib\CORE"   CppGuessTest.c
# "C:\sp522\perl\bin\perl.exe" -MExtUtils::Mksymlists \
#      -e "Mksymlists('NAME'=>\"CppGuessTest\", 'DLBASE' => 'CppGuessTest', 'DL_
FUNCS' => {  }, 'FUNCLIST' => [], 'IMPORTS' => {  }, 'DL_VARS' => []);"
# dlltool --def CppGuessTest.def --output-exp dll.exp
# g++.exe -o blib\arch\auto\CppGuessTest\CppGuessTest.xs.dll -Wl,--base-file -Wl
,dll.base -mdll -s -L"C:\sp522\perl\lib\CORE" -L"C:\sp522\c\lib" CppGuessTest.o
-lstdc++  "C:\sp522\perl\lib\CORE\libperl522.a" -lmoldname -lkernel32 -luser32 -
lgdi32 -lwinspool -lcomdlg32 -ladvapi32 -lshell32 -lole32 -loleaut32 -lnetapi32
-luuid -lws2_32 -lmpr -lwinmm -lversion -lodbc32 -lodbccp32 -lcomctl32 dll.exp
# dlltool --def CppGuessTest.def --base-file dll.base --output-exp dll.exp
# g++.exe -o blib\arch\auto\CppGuessTest\CppGuessTest.xs.dll -mdll -s -L"C:\sp52
2\perl\lib\CORE" -L"C:\sp522\c\lib" CppGuessTest.o -lstdc++  "C:\sp522\perl\lib\
CORE\libperl522.a" -lmoldname -lkernel32 -luser32 -lgdi32 -lwinspool -lcomdlg32
-ladvapi32 -lshell32 -lole32 -loleaut32 -lnetapi32 -luuid -lws2_32 -lmpr -lwinmm
 -lversion -lodbc32 -lodbccp32 -lcomctl32 dll.exp
# "C:\sp522\perl\bin\perl.exe" -MExtUtils::Command -e chmod -- 755 blib\arch\aut
o\CppGuessTest\CppGuessTest.xs.dll
# ========================================
# make test output
# ========================================
# "C:\sp522\perl\bin\perl.exe" "-MExtUtils::Command::MM" "-MTest::Harness" "-e"
"undef *Test::Harness::Switches; test_harness(0, 'blib\lib', 'blib\arch')" t/*.t

# CppGuessTest.c: loadable library and perl binaries are mismatched (got handsha
ke key 0AD00080, needed 0AF00080)
# t/001_load.t ..
# Dubious, test returned 1 (wstat 256, 0x100)
# Failed 1/1 subtests
# CppGuessTest.c: loadable library and perl binaries are mismatched (got handsha
ke key 0AD00080, needed 0AF00080)
# t/002_base.t ..
# Dubious, test returned 1 (wstat 256, 0x100)
# Failed 2/2 subtests
#
# Test Summary Report
# -------------------
# t/001_load.t (Wstat: 256 Tests: 0 Failed: 0)
#   Non-zero exit status: 1
#   Parse errors: Bad plan.  You planned 1 tests but ran 0.
# t/002_base.t (Wstat: 256 Tests: 0 Failed: 0)
#   Non-zero exit status: 1
#   Parse errors: Bad plan.  You planned 2 tests but ran 0.
# Files=2, Tests=0,  1 wallclock secs ( 0.09 usr +  0.00 sys =  0.09 CPU)
# Result: FAIL
# Failed 2/2 test programs. 0/0 subtests failed.
# dmake:  Error code 129, while making 'test_dynamic'
# ========================================
# Looks like you failed 1 test of 1.
t/011_makemaker.t ..... Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests

Test Summary Report
-------------------
t/011_makemaker.t   (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=3, Tests=4, 12 wallclock secs ( 0.06 usr +  0.03 sys =  0.10 CPU)
Result: FAIL
Failed 1/3 test programs. 1/4 subtests failed.
dmake:  Error code 129, while making 'test_dynamic'
```

after
```
C:\sources\extutils-cppguess>dmake test
cp lib/ExtUtils/CppGuess.pm blib\lib\ExtUtils\CppGuess.pm
"C:\sp522\perl\bin\perl.exe" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "u
ndef *Test::Harness::Switches; test_harness(0, 'blib\lib', 'blib\arch')" t/*.t
t/001_load.t .......... 1/2 # EUMM:$VAR1 = {
#           'CCFLAGS' => ' -s -O2 -DWIN32  -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLIC
IT_CONTEXT -DPERL_IMPLICIT_SYS -fwrapv -fno-strict-aliasing -mms-bitfields  -xc+
+ ',
#           'dynamic_lib' => {
#                              'OTHERLDFLAGS' => ' -lstdc++ '
#                            }
#         };
# ---
# MB:$VAR1 = {
#           'extra_linker_flags' => ' -lstdc++ ',
#           'extra_compiler_flags' => ' -s -O2 -DWIN32  -DPERL_TEXTMODE_SCRIPTS
-DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -fwrapv -fno-strict-aliasing -mms-bi
tfields  -xc++ '
#         };
t/001_load.t .......... ok
t/010_module_build.t .. ok
t/011_makemaker.t ..... ok
All tests successful.
Files=3, Tests=4, 11 wallclock secs ( 0.08 usr +  0.00 sys =  0.08 CPU)
Result: PASS

C:\sources\extutils-cppguess>
```