### PR TITLE
add Sun C support for EUMM [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: perl
+perl:
+  - "5.14"
+matrix:
+  include:
+    - perl: 5.24
+      env: AUTHOR_TESTING=1 RELEASE_TESTING=1
+#      env: COVERAGE=1
+sudo: false
+before_install:
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
+  - source ~/travis-perl-helpers/init
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR             # $BUILD_DIR is set by the build-dist command
+install:
+  - cpan-install --deps       # installs prereqs, including recommends
+#  - cpan-install --coverage   # installs converage prereqs, if enabled
+#before_script:
+#  - coverage-setup
+script:
+  - prove -l -j$(test-jobs) $(test-files)   # parallel testing
+#after_success:
+#  - coverage-report
+#notifications:
+#  irc:
+#    channels:
+#    - "irc.perl.org#graphql-perl"
+#    on_failure: always
+#    skip_join: true

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension ExtUtils::CppGuess.
 
+0.13	
+    - repo tidied slightly
+
 0.12	Sat Oct 21 18:12:51 BST 2017
     - Fix tests on 5.26 without '.' in @INC (kentfredric)
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,19 +1,21 @@
-Makefile.PL
 Changes
+lib/ExtUtils/CppGuess.pm
+Makefile.PL
 MANIFEST			This list of files
-README
 META.json
 META.yml
-lib/ExtUtils/CppGuess.pm
+README
 t/001_load.t
 t/010_module_build.t
 t/011_makemaker.t
+t/lib/Guess.pm
+t/lib/TestGuess.pm
 t/lib/TestUtils.pm
 t/module/Build.PL
 t/module/CppGuessTest.xs
-t/module/MANIFEST
-t/module/Makefile.PL
 t/module/lib/CppGuessTest.pm
+t/module/Makefile.PL
+t/module/MANIFEST
 t/module/t/001_load.t
 t/module/t/002_base.t
 t/module/typemap

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,8 +2,6 @@ Changes
 lib/ExtUtils/CppGuess.pm
 Makefile.PL
 MANIFEST			This list of files
-META.json
-META.yml
 README
 t/001_load.t
 t/010_module_build.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,3 +1,4 @@
+\.travis\.yml
 
 #!start included /opt/perl/modules/lib/perl5/ExtUtils/MANIFEST.SKIP
 # Avoid version control files.

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -19,6 +19,7 @@
 
 # Avoid Makemaker generated and utility files.
 \bMANIFEST\.bak
+\bMANIFEST\.SKIP
 \bMakefile$
 \bblib/
 \bMakeMaker-\d


### PR DESCRIPTION
I apologize for the incompleteness of this PR, but perhaps someone looking into this at a later date can carry this over the end zone.

The problem: the Sun C compiler can't as far as I can tell be coerced into compiling C++ by arguments alone.  Instead you need to invoke the C++ compiler, which is CC.  I managed to get this working for EUMM, but couldn't quite get it to work on MB.  This is what I have so far for MB:  (on top of this PR):

```diff
diff --git a/lib/ExtUtils/CppGuess.pm b/lib/ExtUtils/CppGuess.pm
index 332b72b..fc30a5b 100644
--- a/lib/ExtUtils/CppGuess.pm
+++ b/lib/ExtUtils/CppGuess.pm
@@ -236,13 +236,20 @@ sub makemaker_options {
 sub module_build_options {
     my $self = shift;
 
+    my $cc     = $self->_get_cc;
+    my $ld     = $self->_get_ld;
     my $lflags = $self->_get_lflags;
     my $cflags = $self->_get_cflags;
 
-    return (
+    my %config = (
       extra_compiler_flags => $cflags,
       extra_linker_flags   => $lflags,
     );
+
+    $config{config}->{cc} = $cc if defined $cc;
+    $config{config}->{ld}  = $ld if defined $ld;
+
+    %config;
 }
```

Looking at MB it looks like this ought to work, but running this through the debugger, it seems as though `ExtUtils::CBuilder` is overriding the value of `cc` (though not `ld`).  Not sure if this is a bug in MB/CB, just it being broken by design, or maybe I misunderstand how you are supposed to override the C compiler in MB.

Improvements that could be made to this PR (aside from MB support of course): perhaps only bother checking this on `solaris` or `linux`, as I think these are the only platforms that are supported by the Sun C++ compiler.  Or maybe even just `solaris`.  I am not even sure if the linux version of Sun C is supported by Perl, I tend to doubt it.

Related: https://rt.cpan.org/Public/Bug/Display.html?id=101865