### PR TITLE
don't duplicate compiler flags in Module::Build

### DIFF
--- a/lib/ExtUtils/CppGuess.pm
+++ b/lib/ExtUtils/CppGuess.pm
@@ -286,10 +286,10 @@ EOF
 }
 
 sub _get_cflags {
-  my $self = shift;
+  my ($self, $omit_ccflags) = @_;
   $self->guess_compiler or die;
   join ' ', '', map _trim_whitespace($_), grep defined && length,
-    $self->_config->{ccflags},
+    ($omit_ccflags ? '' : $self->_config->{ccflags}),
     $self->{guess}{extra_cflags},
     $self->{extra_compiler_flags},
     ($self->is_clang ? '-Wno-reserved-user-defined-literal' : ()),
@@ -323,7 +323,10 @@ sub module_build_options {
     my $self = shift;
 
     my $lflags = $self->_get_lflags;
-    my $cflags = $self->_get_cflags;
+    # We're omitting ccflags to avoid duplication of flags, because unlike
+    # makemaker, we're appending to the compiler flags, not overriding
+    # them. They already contain $Config{ccflags}.
+    my $cflags = $self->_get_cflags(1);
 
     return (
       extra_compiler_flags => $cflags,


### PR DESCRIPTION
For Module::Build, unlike MakeMaker, we're appending to the
compiler flags, not overriding them. Therefore, we don't have to
add $Config{ccflags} because it's already there.