### PR TITLE
clang on macOS calls itself "Apple LLVM"

### DIFF
--- a/lib/ExtUtils/CppGuess.pm
+++ b/lib/ExtUtils/CppGuess.pm
@@ -412,9 +412,9 @@ sub _cc_is_clang {
     $self->{is_clang} = 0;
     my $cc_version = _capture( "$cc --version" );
     if (
-         $cc_version =~ m/\Aclang/i
+         $cc_version =~ m/\A(?:clang|apple llvm)/i
       || $cc eq 'clang' # because why would they lie?
-      || (($self->_config->{gccversion} || '') =~ /Clang/),
+      || (($self->_config->{gccversion} || '') =~ /Clang|Apple LLVM/),
     ) {
       $self->{is_clang} = 1;
     }


### PR DESCRIPTION
For reference, here's the output of a few relevant commands:

```
% perl -MConfig -MData::Dumper -E 'say Dumper {%Config{qw/ccname cc gccversion ccversion/}}'
$VAR1 = {
          'gccversion' => '4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.10.44.4)',
          'ccversion' => '',
          'ccname' => 'gcc',
          'cc' => 'cc'
        };

% cc --version
Apple LLVM version 10.0.0 (clang-1000.10.44.4)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```