### PR TITLE
Add C++ standard support flag detection

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.22 «DATE»
+    - Add C++ standard support flag detection.
+      See <https://github.com/tsee/extutils-cppguess/pull/24>.
+
 0.21 2020-01-23
 - no give $Config{ccflags} in Module::Build as add not replace - thanks @xenu
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ README
 t/00-report-prereqs.t
 t/001_load.t
 t/002_icpp.t
+t/003_standard_flag.t
 t/010_module_build.t
 t/011_makemaker.t
 t/lib/Guess.pm

--- a/lib/ExtUtils/CppGuess.pm
+++ b/lib/ExtUtils/CppGuess.pm
@@ -170,7 +170,7 @@ Given a string C<$standard_name> that is currently one of
 returns a string with a flag that can be used to tell the compiler to support
 that version of the C++ standard or dies if version is not supported.
 
-Added in «TODO VERSION».
+Added in version v0.22.
 
 =head1 AUTHOR
 

--- a/t/003_standard_flag.t
+++ b/t/003_standard_flag.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Test::More;
+use ExtUtils::CppGuess;
+
+my $guess = ExtUtils::CppGuess->new;
+
+plan skip_all => "Test currently only supports GCC and Clang"
+	unless $guess->is_gcc || $guess->is_clang;
+
+subtest "Test argument C++11" => sub {
+	my $flag = eval {
+		$guess->cpp_standard_flag('C++11');
+	};
+	if( $@ =~ /does not support any flags for standard/ ) {
+		plan skip_all => "Skipping: $@";
+	}
+	like $flag, qr/\Q-std=c++\E(11|0x)/, 'correct flag';
+};
+
+subtest "Test non-C++ standard" => sub {
+	my $flag = eval {
+		# The flag `-std=c11` is a valid compiler flag,
+		# but not for C++.
+		$guess->cpp_standard_flag('C11');
+	};
+	ok $@ =~ /Unknown standard/, 'C11 is not a C++ standard';
+};
+
+done_testing;

--- a/t/003_standard_flag.t
+++ b/t/003_standard_flag.t
@@ -27,4 +27,20 @@ subtest "Test non-C++ standard" => sub {
 	ok $@ =~ /Unknown standard/, 'C11 is not a C++ standard';
 };
 
+subtest "Test compiler failure to support known version" => sub {
+	# NOTE Monkey-patching data here.
+	local $ExtUtils::CppGuess::CPP_STANDARD_FLAGS;
+	for my $compiler ( qw(is_gcc is_clang) ) {
+		$ExtUtils::CppGuess::CPP_STANDARD_FLAGS
+			->{$compiler}{'C++unreal'} = [ '-std=c++unreal' ];
+	}
+
+	my $flag = eval {
+		# This will try to use the fake C++unreal flag, but fail.
+		$guess->cpp_standard_flag('C++unreal');
+	};
+
+	ok $@ =~ /does not support/, 'Fake version is not supported by compiler';
+};
+
 done_testing;


### PR DESCRIPTION
This checks alternative flags for a given C++ standard name and returns
the first version that compiles. Otherwise it dies.
