### PR TITLE
Fix 0.27 test failures in 002_icpp.t

### DIFF
--- a/t/002_icpp.t
+++ b/t/002_icpp.t
@@ -93,7 +93,13 @@ my @METHODS = qw(
   compiler_command linker_flags
 );
 
-run_test(@$_) for @DATA;
+for (@DATA) {
+  SKIP: {
+    skip 'gcc: provided by Clang on macOS' if $^O eq 'darwin'
+      && $_->[0]{cc} eq 'gcc' && ($_->[0]{config}{gccversion} || '') ne 'Clang';
+    run_test(@$_);
+  }
+}
 
 # mock some compiler output
 my $old_capture = \&ExtUtils::CppGuess::_capture;

--- a/t/002_icpp.t
+++ b/t/002_icpp.t
@@ -101,6 +101,7 @@ our $CAPTURES;
 {
   no warnings "redefine";
   *ExtUtils::CppGuess::_capture =
+  *ExtUtils::CppGuess::_capture_empty_stdin =
     sub {
       my @cmd = @_;
       if (my $result = $CAPTURES->{"@cmd"}) {
@@ -140,7 +141,10 @@ my @CAPS =
          compiler_command => 'g++ -xc++',
          linker_flags => '-lstdc++',
        },
-       { "cc --version" => "cc (Debian 12.2.0-14) 12.2.0" },
+       {
+         "cc --version" => "cc (Debian 12.2.0-14) 12.2.0",
+         "cc -dM -E -" => "#define __GNUC__ 4",
+       },
      ],
     );
 


### PR DESCRIPTION
Resolves #31 by skipping the affected tests on macOS only.

I *think* this patch will also resolve the problem with the mocking described in #30 and #32, but I don’t have access to one of the platforms that apparently are affected.

@shawnlaffan would you mind verifying this on Strawberry, please?